### PR TITLE
fe/feat: 레이아웃 및 라우팅 초기 셋업

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,80 +1,87 @@
-import { Button, Input, Space, Typography } from 'antd'
-import { useState } from 'react'
-import { Link, Route, Routes } from 'react-router-dom'
-import './App.css'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { Navigate, Route, Routes } from 'react-router-dom';
 
-const HomePage = () => (
-  <div>
-    <h1>환영합니다! 약국 관리 시스템</h1>
-    <p>여기는 메인 페이지입니다.</p>
-    <nav>
-      <ul>
-        <li><Link to="/dashboard">대시보드</Link></li>
-        <li><Link to="/inventory">재고 관리</Link></li>
-        <li><Link to="/orders">발주 관리</Link></li>
-      </ul>
-    </nav>
-    <br />
-    {/* Ant Design 버튼 추가 */}
-    <Space> {/* Ant Design 컴포넌트 간 간격을 위한 Space 컴포넌트 */}
-      <Button type="primary">기본 버튼</Button>
-      <Button>보조 버튼</Button>
-      <Button type="dashed">점선 버튼</Button>
-      <Button type="link">링크 버튼</Button>
-    </Space>
-    <br /><br />
-    {/* Ant Design 입력 필드 추가 */}
-    <Input placeholder="이름을 입력하세요" style={{ width: 200 }} />
-    <br /><br />
-    <Typography.Text type="success">Ant Design 텍스트 예시입니다.</Typography.Text>
-  </div>
-);
+import BranchLayout from './layouts/BranchLayout';
+import HqLayout from './layouts/HqLayout';
+import PublicLayout from './layouts/PublicLayout';
+import BranchDashboardPage from './pages/Branch/BranchDashboardPage';
+import BranchProfileEditPage from './pages/Branch/BranchProfileEditPage';
+import BranchStockPage from './pages/Branch/BranchStockPage';
+import OrderRequestPage from './pages/Branch/OrderRequestPage';
+import ReturnRequestPage from './pages/Branch/ReturnRequestPage';
+import AdminLoginPage from './pages/Common/Auth/AdminLoginPage';
+import AdminRegisterPage from './pages/Common/Auth/AdminRegisterPage';
+import LoginPage from './pages/Common/Auth/LoginPage';
+import LogoutPage from './pages/Common/Auth/LogoutPage';
+import RegisterPage from './pages/Common/Auth/RegisterPage';
+import ForbiddenPage from './pages/Common/Error/ForbiddenPage';
+import NotFoundPage from './pages/Common/Error/NotFoundPage';
+import ServerErrorPage from './pages/Common/Error/ServerErrorPage';
+import NoticeDetailPage from './pages/Common/Notice/NoticeDetailPage';
+import NoticeListPage from './pages/Common/Notice/NoticeListPage';
+import ProductDetailPage from './pages/Common/Product/ProductDetailPage';
+import ProductListPage from './pages/Common/Product/ProductListPage';
+import BranchManagementPage from './pages/HQ/BranchManagementPage';
+import BranchMonitoringPage from './pages/HQ/BranchMonitoringPage';
+import DemandForecastPage from './pages/HQ/DemandForecastPage';
+import HqDashboardPage from './pages/HQ/HqDashboardPage';
+import HqNoticeEditPage from './pages/HQ/HqNoticeEditPage';
+import HqNoticeRegisterPage from './pages/HQ/HqNoticeRegisterPage';
+import HqProductEditPage from './pages/HQ/HqProductEditPage';
+import HqProductRegisterPage from './pages/HQ/HqProductRegisterPage';
+import HqStockPage from './pages/HQ/HqStockPage';
+import OrderManagementPage from './pages/HQ/OrderManagementPage';
+import ReturnManagementPage from './pages/HQ/ReturnManagementPage';
 
-const DashboardPage = () => <h2>대시보드 페이지</h2>;
-const InventoryPage = () => <h2>재고 관리 페이지</h2>;
-const OrdersPage = () => <h2>발주 관리 페이지</h2>;
-const NotFoundPage = () => <h2>페이지를 찾을 수 없습니다 (404)</h2>;
-
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+    <Routes>
+      {/* 공통 */}
+      <Route path="/" element={<PublicLayout />}>
+        {/* 기본 접근 시 로그인 페이지로 리다이렉트*/}
+        <Route index element={<Navigate to="/login" replace />} />
+        {/* 인증 */}
+        <Route path="login" element={<LoginPage />} />
+        <Route path="admin-login" element={<AdminLoginPage />} />
+        <Route path="register" element={<RegisterPage />} />
+        <Route path="admin-register" element={<AdminRegisterPage />} />
+        <Route path="logout" element={<LogoutPage />} />
+        {/* 에러 */}
+        <Route path="403" element={<ForbiddenPage />} />
+        <Route path="500" element={<ServerErrorPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
 
-      {/* <--- 여기부터 라우팅 설정 시작 */}
-      <hr /> {/* 구분선 */}
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/inventory" element={<InventoryPage />} />
-        <Route path="/orders" element={<OrdersPage />} />
-        <Route path="*" element={<NotFoundPage />} /> {/* 일치하는 경로가 없을 때 */}
-      </Routes>
-      {/* <--- 라우팅 설정 끝 */}
-    </>
-  )
+      {/* 본사 */}
+      <Route path="/hq" element={<HqLayout />}>
+        <Route index element={<HqDashboardPage />} />
+        <Route path="notices" element={<NoticeListPage />} />
+        <Route path="notices/:id" element={<NoticeDetailPage />} />
+        <Route path="notices/new" element={<HqNoticeRegisterPage />} />
+        <Route path="notices/:id/edit" element={<HqNoticeEditPage />} />
+        <Route path="branches" element={<BranchManagementPage />} />
+        <Route path="orders" element={<OrderManagementPage />} />
+        <Route path="returns" element={<ReturnManagementPage />} />
+        <Route path="monitoring" element={<BranchMonitoringPage />} />
+        <Route path="forecast" element={<DemandForecastPage />} />
+        <Route path="stock" element={<HqStockPage />} />
+        <Route path="products" element={<ProductListPage />} />
+        <Route path="products/:id" element={<ProductDetailPage />} />
+        <Route path="products/new" element={<HqProductRegisterPage />} />
+        <Route path="products/:id/edit" element={<HqProductEditPage />} />
+      </Route>
+
+      {/* 가맹점 */}
+      <Route path="/branch" element={<BranchLayout />}>
+        <Route index element={<BranchDashboardPage />} />
+        <Route path="profile-edit" element={<BranchProfileEditPage />} />
+        <Route path="notices" element={<NoticeListPage />} />
+        <Route path="notices/:id" element={<NoticeDetailPage />} />
+        <Route path="order-request" element={<OrderRequestPage />} />
+        <Route path="return-request" element={<ReturnRequestPage />} />
+        <Route path="stock" element={<BranchStockPage />} />
+        <Route path="products" element={<ProductListPage />} />
+        <Route path="products/:id" element={<ProductDetailPage />} />
+      </Route>
+    </Routes>
+  );
 }
-
-export default App

--- a/frontend/src/layouts/BranchLayout.tsx
+++ b/frontend/src/layouts/BranchLayout.tsx
@@ -1,0 +1,136 @@
+import {
+  BellOutlined,
+  ContainerFilled,
+  EditOutlined,
+  FrownFilled,
+  LogoutOutlined,
+  NotificationFilled,
+  ShoppingFilled,
+  UserOutlined,
+} from '@ant-design/icons';
+import { ConfigProvider, Dropdown, Layout, Menu, Row, Typography } from 'antd';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+
+const { Sider, Header, Content, Footer } = Layout;
+const { Text } = Typography;
+
+const theme = {
+  components: {
+    Menu: {
+      itemHeight: 38, // 메뉴 아이템 높이 (default 40)
+      itemMarginBlock: 24, // 메뉴 아이템 margin-block (default 4)
+      itemMarginInline: 4, // 메뉴 아이템 수평 margin (default 4)
+      itemPaddingInline: 16, // 메뉴 아이템 padding-inline (default 16)
+    },
+    Layout: {
+      headerPadding: '0 48px', // 헤더 padding (default 0 50px)
+    },
+    Dropdown: {
+      paddingBlock: 8, // 드롭다운 수직 padding (default 5)
+    },
+  },
+};
+
+const siderMenuItems = [
+  {
+    key: 'notices',
+    label: <Link to="/branch/notices">공지사항</Link>,
+    icon: <NotificationFilled />,
+  },
+  {
+    key: 'stock',
+    label: <Link to="/branch/stock">재고관리</Link>,
+    icon: <ContainerFilled />,
+  },
+  {
+    key: 'order-request',
+    label: <Link to="/branch/order-request">발주요청</Link>,
+    icon: <ShoppingFilled />,
+  },
+  {
+    key: 'return-request',
+    label: <Link to="/branch/return-request">반품요청</Link>,
+    icon: <FrownFilled />,
+  },
+];
+
+const avatarMenuItems = {
+  items: [
+    {
+      key: 'profile-edit',
+      label: <Link to="/branch/profile-edit">내 정보 수정</Link>,
+      icon: <EditOutlined />,
+    },
+    {
+      key: 'logout',
+      label: <Link to="/logout">로그아웃</Link>,
+      icon: <LogoutOutlined />,
+      danger: true,
+    },
+  ],
+};
+
+export default function BranchLayout() {
+  const location = useLocation();
+
+  const getSelectedKeys = () => {
+    const path = location.pathname;
+    for (let item of siderMenuItems) {
+      if (item.label && item.label.props && item.label.props.to) {
+        const itemPath = item.label.props.to;
+        if (path === itemPath || path.startsWith(`${itemPath}/`)) {
+          return [item.key];
+        }
+      }
+    }
+    return [];
+  };
+
+  const selectedKeys = getSelectedKeys();
+
+  return (
+    <ConfigProvider theme={theme}>
+      <Layout style={{ height: '100vh' }}>
+        <Header
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Link to="/branch">예약</Link>
+          <Row>
+            <Text style={{ color: '#ffffff' }}>에이블 약국</Text>
+            <BellOutlined style={{ fontSize: '24px', margin: '0 24px', color: '#ffffff' }} />
+            <Dropdown
+              trigger={['click']}
+              menu={avatarMenuItems}
+              placement="bottomRight"
+              arrow={{ pointAtCenter: true }}
+            >
+              <UserOutlined style={{ fontSize: '24px', color: '#ffffff' }} />
+            </Dropdown>
+          </Row>
+        </Header>
+        <Layout>
+          <Sider style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Menu
+              theme="dark"
+              style={{ width: '100%' }}
+              items={siderMenuItems}
+              selectedKeys={selectedKeys}
+            ></Menu>
+          </Sider>
+          <Layout>
+            <Content style={{ margin: '24px', padding: '24px' }}>
+              <Outlet />
+            </Content>
+            <Footer style={{ textAlign: 'center' }}>© 2025 Team yeahyak</Footer>
+          </Layout>
+        </Layout>
+      </Layout>
+      {/*<Chatbot />*/}
+    </ConfigProvider>
+  );
+}

--- a/frontend/src/layouts/HqLayout.tsx
+++ b/frontend/src/layouts/HqLayout.tsx
@@ -1,0 +1,148 @@
+import {
+  ApartmentOutlined,
+  AreaChartOutlined,
+  BellOutlined,
+  BulbFilled,
+  ContainerFilled,
+  LogoutOutlined,
+  MinusSquareFilled,
+  NotificationFilled,
+  PlusSquareFilled,
+  UserOutlined,
+} from '@ant-design/icons';
+import { ConfigProvider, Dropdown, Layout, Menu, Row, Typography } from 'antd';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+
+const { Sider, Header, Content, Footer } = Layout;
+const { Text } = Typography;
+
+const theme = {
+  components: {
+    Menu: {
+      itemHeight: 38, // 메뉴 아이템 높이 (default 40)
+      itemMarginBlock: 24, // 메뉴 아이템 margin-block (default 4)
+      itemMarginInline: 4, // 메뉴 아이템 수평 margin (default 4)
+      itemPaddingInline: 16, // 메뉴 아이템 padding-inline (default 16)
+    },
+    Layout: {
+      headerPadding: '0 48px', // 헤더 padding (default 0 50px)
+    },
+    Dropdown: {
+      paddingBlock: 8, // 드롭다운 수직 padding (default 5)
+    },
+  },
+};
+
+const siderMenuItems = [
+  {
+    key: 'notices',
+    label: <Link to="/hq/notices">공지사항</Link>,
+    icon: <NotificationFilled />,
+  },
+  {
+    key: 'branches',
+    label: <Link to="/hq/branches">가맹점 관리</Link>,
+    icon: <ApartmentOutlined />,
+  },
+  {
+    key: 'orders',
+    label: <Link to="/hq/orders">발주요청 관리</Link>,
+    icon: <PlusSquareFilled />,
+  },
+  {
+    key: 'returns',
+    label: <Link to="/hq/returns">반품요청 관리</Link>,
+    icon: <MinusSquareFilled />,
+  },
+  {
+    key: 'monitoring',
+    label: <Link to="/hq/monitoring">가맹점 모니터링</Link>,
+    icon: <AreaChartOutlined />,
+  },
+  {
+    key: 'forecast',
+    label: <Link to="/hq/forecast">수요예측</Link>,
+    icon: <BulbFilled />,
+  },
+  {
+    key: 'stock',
+    label: <Link to="/hq/stock">재고관리</Link>,
+    icon: <ContainerFilled />,
+  },
+];
+
+const avatarMenuItems = {
+  items: [
+    {
+      key: 'logout',
+      label: <Link to="/logout">로그아웃</Link>,
+      icon: <LogoutOutlined />,
+      danger: true,
+    },
+  ],
+};
+
+export default function HqLayout() {
+  const location = useLocation();
+
+  const getSelectedKeys = () => {
+    const path = location.pathname;
+    for (let item of siderMenuItems) {
+      if (item.label && item.label.props && item.label.props.to) {
+        const itemPath = item.label.props.to;
+        if (path === itemPath || path.startsWith(`${itemPath}/`)) {
+          return [item.key];
+        }
+      }
+    }
+    return [];
+  };
+
+  const selectedKeys = getSelectedKeys();
+
+  return (
+    <ConfigProvider theme={theme}>
+      <Layout style={{ height: '100vh' }}>
+        <Header
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Link to="/hq">예약</Link>
+          <Row>
+            <Text style={{ color: '#ffffff' }}>송쫑이 직원</Text>
+            <BellOutlined style={{ fontSize: '24px', margin: '0 24px', color: '#ffffff' }} />
+            <Dropdown
+              trigger={['click']}
+              menu={avatarMenuItems}
+              placement="bottomRight"
+              arrow={{ pointAtCenter: true }}
+            >
+              <UserOutlined style={{ fontSize: '24px', color: '#ffffff' }} />
+            </Dropdown>
+          </Row>
+        </Header>
+        <Layout>
+          <Sider style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Menu
+              theme="dark"
+              style={{ width: '100%' }}
+              items={siderMenuItems}
+              selectedKeys={selectedKeys}
+            ></Menu>
+          </Sider>
+          <Layout>
+            <Content style={{ margin: '24px', padding: '24px' }}>
+              <Outlet />
+            </Content>
+            <Footer style={{ textAlign: 'center' }}>© 2025 Team yeahyak</Footer>
+          </Layout>
+        </Layout>
+      </Layout>
+      {/*<Chatbot />*/}
+    </ConfigProvider>
+  );
+}

--- a/frontend/src/layouts/PublicLayout.tsx
+++ b/frontend/src/layouts/PublicLayout.tsx
@@ -1,0 +1,24 @@
+import { Layout } from 'antd';
+import { Outlet } from 'react-router-dom';
+
+const { Content, Footer } = Layout;
+
+export default function PublicLayout() {
+  return (
+    <Layout style={{ height: '100vh' }}>
+      <Content
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          margin: '24px',
+          padding: '24px',
+        }}
+      >
+        <Outlet />
+      </Content>
+      <Footer style={{ textAlign: 'center' }}>© 2025 Team yeahyak</Footer>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/Branch/BranchDashboardPage.tsx
+++ b/frontend/src/pages/Branch/BranchDashboardPage.tsx
@@ -1,0 +1,8 @@
+export default function BranchDashboardPage() {
+  return (
+    <div>
+      <h1>Welcome to the Pharmacy Home Page</h1>
+      <p>This is the main page for the pharmacy application.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Branch/BranchProfileEditPage.tsx
+++ b/frontend/src/pages/Branch/BranchProfileEditPage.tsx
@@ -1,0 +1,7 @@
+export default function BranchProfileEditPage() {
+  return (
+    <div>
+      <h1>가맹점 정보 수정 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Branch/BranchStockPage.tsx
+++ b/frontend/src/pages/Branch/BranchStockPage.tsx
@@ -1,0 +1,7 @@
+export default function BranchStockPage() {
+  return (
+    <div>
+      <h1>가맹점 재고 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Branch/OrderRequestPage.tsx
+++ b/frontend/src/pages/Branch/OrderRequestPage.tsx
@@ -1,0 +1,7 @@
+export default function OrderRequestPage() {
+  return (
+    <div>
+      <h1>발주요청 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Branch/ReturnRequestPage.tsx
+++ b/frontend/src/pages/Branch/ReturnRequestPage.tsx
@@ -1,0 +1,7 @@
+export default function ReturnRequestPage() {
+  return (
+    <div>
+      <h1>반품요청 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Auth/AdminLoginPage.tsx
+++ b/frontend/src/pages/Common/Auth/AdminLoginPage.tsx
@@ -1,0 +1,7 @@
+export default function AdminLoginPage() {
+  return (
+    <div>
+      <h1>관리자 로그인 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Auth/AdminRegisterPage.tsx
+++ b/frontend/src/pages/Common/Auth/AdminRegisterPage.tsx
@@ -1,0 +1,7 @@
+export default function AdminRegisterPage() {
+  return (
+    <div>
+      <h1>관리자 회원가입 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Common/Auth/LoginPage.tsx
@@ -1,0 +1,7 @@
+export default function LoginPage() {
+  return (
+    <div>
+      <h1>일반 로그인 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Auth/LogoutPage.tsx
+++ b/frontend/src/pages/Common/Auth/LogoutPage.tsx
@@ -1,0 +1,7 @@
+export default function LogoutPage() {
+  return (
+    <div>
+      <h1>로그아웃 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Common/Auth/RegisterPage.tsx
@@ -1,0 +1,7 @@
+export default function RegisterPage() {
+  return (
+    <div>
+      <h1>일반 회원가입 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Error/ForbiddenPage.tsx
+++ b/frontend/src/pages/Common/Error/ForbiddenPage.tsx
@@ -1,0 +1,11 @@
+import { Result } from 'antd';
+
+export default function ForbiddenPage() {
+  return (
+    <Result
+      status="403"
+      title="403"
+      subTitle="Sorry, you are not authorized to access this page."
+    />
+  );
+}

--- a/frontend/src/pages/Common/Error/NotFoundPage.tsx
+++ b/frontend/src/pages/Common/Error/NotFoundPage.tsx
@@ -1,0 +1,5 @@
+import { Result } from 'antd';
+
+export default function NotFoundPage() {
+  return <Result status="404" title="404" subTitle="Sorry, the page you visited does not exist." />;
+}

--- a/frontend/src/pages/Common/Error/ServerErrorPage.tsx
+++ b/frontend/src/pages/Common/Error/ServerErrorPage.tsx
@@ -1,0 +1,5 @@
+import { Result } from 'antd';
+
+export default function ServerErrorPage() {
+  return <Result status="500" title="500" subTitle="Sorry, something went wrong." />;
+}

--- a/frontend/src/pages/Common/Notice/NoticeDetailPage.tsx
+++ b/frontend/src/pages/Common/Notice/NoticeDetailPage.tsx
@@ -1,0 +1,7 @@
+export default function NoticeDetailPage() {
+  return (
+    <div>
+      <h1>공지사항 상세 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Notice/NoticeListPage.tsx
+++ b/frontend/src/pages/Common/Notice/NoticeListPage.tsx
@@ -1,0 +1,7 @@
+export default function NoticeListPage() {
+  return (
+    <div>
+      <h1>공지사항 목록 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Product/ProductDetailPage.tsx
+++ b/frontend/src/pages/Common/Product/ProductDetailPage.tsx
@@ -1,0 +1,7 @@
+export default function ProductDetailPage() {
+  return (
+    <div>
+      <h1>의약품 상세 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/Common/Product/ProductListPage.tsx
+++ b/frontend/src/pages/Common/Product/ProductListPage.tsx
@@ -1,0 +1,7 @@
+export default function ProductListPage() {
+  return (
+    <div>
+      <h1>의약품 목록 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/BranchManagementPage.tsx
+++ b/frontend/src/pages/HQ/BranchManagementPage.tsx
@@ -1,0 +1,7 @@
+export default function BranchManagementPage() {
+  return (
+    <div>
+      <h1>가맹점 관리 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/BranchMonitoringPage.tsx
+++ b/frontend/src/pages/HQ/BranchMonitoringPage.tsx
@@ -1,0 +1,7 @@
+export default function BranchMonitoringPage() {
+  return (
+    <div>
+      <h1>지점별 현황 모니터링 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/DemandForecastPage.tsx
+++ b/frontend/src/pages/HQ/DemandForecastPage.tsx
@@ -1,0 +1,7 @@
+export default function DemandForecastPage() {
+  return (
+    <div>
+      <h1>전국 수요 예측 및 발주 수량 추천 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/HqDashboardPage.tsx
+++ b/frontend/src/pages/HQ/HqDashboardPage.tsx
@@ -1,0 +1,7 @@
+export default function HqDashboardPage() {
+  return (
+    <div>
+      <h1>본사 홈 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/HqNoticeEditPage.tsx
+++ b/frontend/src/pages/HQ/HqNoticeEditPage.tsx
@@ -1,0 +1,7 @@
+export default function HqNoticeEditPage() {
+  return (
+    <div>
+      <h1>공지사항 수정 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/HqNoticeRegisterPage.tsx
+++ b/frontend/src/pages/HQ/HqNoticeRegisterPage.tsx
@@ -1,0 +1,7 @@
+export default function HqNoticeRegisterPage() {
+  return (
+    <div>
+      <h1>공지사항 등록 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/HqProductEditPage.tsx
+++ b/frontend/src/pages/HQ/HqProductEditPage.tsx
@@ -1,0 +1,7 @@
+export default function HqProductEditPage() {
+  return (
+    <div>
+      <h1>의약품 수정 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/HqProductRegisterPage.tsx
+++ b/frontend/src/pages/HQ/HqProductRegisterPage.tsx
@@ -1,0 +1,7 @@
+export default function HqProductRegisterPage() {
+  return (
+    <div>
+      <h1>의약품 등록 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/HqStockPage.tsx
+++ b/frontend/src/pages/HQ/HqStockPage.tsx
@@ -1,0 +1,7 @@
+export default function HqStockPage() {
+  return (
+    <div>
+      <h1>본사 재고 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/OrderManagementPage.tsx
+++ b/frontend/src/pages/HQ/OrderManagementPage.tsx
@@ -1,0 +1,7 @@
+export default function OrderManagementPage() {
+  return (
+    <div>
+      <h1>발주요청 관리 페이지</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/HQ/ReturnManagementPage.tsx
+++ b/frontend/src/pages/HQ/ReturnManagementPage.tsx
@@ -1,0 +1,7 @@
+export default function ReturnManagementPage() {
+  return (
+    <div>
+      <h1>반품요청 관리 페이지</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
- [x] `PublicLayout`, `HqLayout`, `BranchLayout` 컴포넌트 생성
- [x] 공통, 본사, 가맹점 페이지 디렉토리 구조 및 빈 컴포넌트 정의
- [x] `App.tsx`에서 역할별 레이아웃에 따라 중첩 라우팅 구성