### PR TITLE
fe/refactor: 발주 및 반품 페이지 api 연동 마무리

### DIFF
--- a/frontend/src/pages/Branch/OrderRequestPage.tsx
+++ b/frontend/src/pages/Branch/OrderRequestPage.tsx
@@ -147,7 +147,6 @@ export default function OrderRequestPage() {
           pharmacyId: pharmacyProfile.pharmacyId, // [수정] 타입 단언된 pharmacyProfile 사용
           page: page - 1,
           size: 5,
-          status: 'REQUESTED', // 예시: 요청 상태만 가져오기 (필요에 따라 변경)
         },
       });
       if (response.data.success) {
@@ -172,7 +171,7 @@ export default function OrderRequestPage() {
         params: { page: page - 1, size: 5, keyword },
       });
       if (response.data.success) {
-        const { content, totalElements, number } = response.data.data.body; // [수정] 응답 데이터 구조 변경에 따라 body 객체 추가
+        const { data: content, totalElements, currentPage: number } = response.data; // [수정] 응답 데이터 구조 변경에 따라 body 객체 제거 및 필드명 수정
         setProducts(content);
         setProductTotal(totalElements);
         setProductPage(number + 1);

--- a/frontend/src/pages/HQ/OrderManagementPage.tsx
+++ b/frontend/src/pages/HQ/OrderManagementPage.tsx
@@ -178,7 +178,7 @@ export default function OrderManagementPage() {
     try {
       // [변경] API 엔드포인트에 따라 조건부 호출
       if (newStatus === 'APPROVED') {
-        await instance.patch(`/orders/${orderId}/approve`);
+        await instance.post(`/orders/${orderId}/approve`);
       } else if (newStatus === 'CANCELED') {
         await instance.patch(`/orders/${orderId}/reject`);
       } else {


### PR DESCRIPTION
발주 요청 및 관리 페이지 승인 버튼 연동
반품 요청 및 반품 관리 페이지 api 연동 마무리
페이지 UI 개선, 상세내용 모달 UI 개선

vite.config.ts와 api.ts 수정해서 사용

<백엔드 기능 요구사항>
현재 반품 요청 관리 페이지에서 반품 거절 사유 입력을 받을 수 있는데, 백엔드에 이걸 저장하고 처리하는 로직이 없음
추가가  필요함



<백엔드 로직 로컬 변경사항 ( 커밋 X )>
1. OrderService.java 파일에서 orderStatus와 orderRepository 수정해서 사용
2. OrderRepository.java 파일에서 약국 ID로만 조회하는 메소드 추가해서 사용
3. ReturnController.java 파일에서 RequestMapping("api/branch/returns")로 수정해서 사용
4. AdminReturnController.java 파일에서 RequestMapping("api/admin/returns")로 수정해서 사용
5. SecurityConfig 임시로 모든 포트 허용으로 변경해서 사용