### PR TITLE
fe/fix: 발주, 반품 API 변경점 및 페이지네이션 적용, 로직 변경

### DIFF
--- a/frontend/src/pages/Branch/OrderRequestPage.tsx
+++ b/frontend/src/pages/Branch/OrderRequestPage.tsx
@@ -18,6 +18,7 @@ import {
 } from 'antd';
 import React, { useState, useEffect, useCallback } from 'react';
 import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined } from '@ant-design/icons';
 // API 통신을 위한 axios 인스턴스를 가져옵니다.
 import { instance as api } from '../../api/api';
 // 전역 상태 관리를 위한 zustand 스토어를 가져옵니다。
@@ -459,9 +460,22 @@ export default function OrderRequestPage() {
           {/* 주문 내역 섹션 */}
           <Row style={{ marginTop: 40, marginBottom: 100 }}>
             <Col span={24}>
-              <Text strong style={{ fontSize: 20, marginBottom: 12, display: 'block' }}>
-                주문 내역
-              </Text>
+              <Row justify="space-between" align="middle" style={{ marginBottom: 12 }}>
+                <Col>
+                  <Text strong style={{ fontSize: 20 }}>
+                    주문 내역
+                  </Text>
+                </Col>
+                <Col>
+                  <Button
+                    icon={<ReloadOutlined />}
+                    onClick={() => fetchOrderHistory(orderPage)}
+                    loading={loading.orders}
+                  >
+                    새로고침
+                  </Button>
+                </Col>
+              </Row>
               <Spin spinning={loading.orders}>
                 <Table<OrderHistory>
                   columns={orderHistoryColumns}

--- a/frontend/src/pages/Branch/ReturnRequestPage.tsx
+++ b/frontend/src/pages/Branch/ReturnRequestPage.tsx
@@ -1,7 +1,10 @@
+
+// 필요한 antd 컴포넌트 및 React 훅들을 가져옵니다.
 import {
   Button,
   Card,
   Col,
+  Descriptions,
   Form,
   Input,
   InputNumber,
@@ -12,33 +15,30 @@ import {
   Tag,
   Typography,
   message,
-  Descriptions // Descriptions import 추가
 } from 'antd';
 import React, { useState, useEffect, useCallback } from 'react';
-import type { ColumnsType } from 'antd/es/table';
+import type { ColumnsType, TableProps } from 'antd/es/table';
 import { instance as api } from '../../api/api';
 import { useAuthStore } from '../../stores/authStore';
 import type { Pharmacy } from '../../types/profile.type';
+import { ReloadOutlined } from '@ant-design/icons';
 
 const { Option } = Select;
 const { Title } = Typography;
 
 // --- 타입 정의 ---
-
-// [수정] 백엔드 ReturnResponseDto에 맞춘 반품 내역 타입
 interface ReturnResponse {
   returnId: number;
   pharmacyId: number;
   pharmacyName: string;
-  orderId: number | null; // orderId가 null일 수 있음
+  orderId: number | null;
   createdAt: string;
-  updatedAt: string | null; // updatedAt이 null일 수 있음
+  updatedAt: string | null;
   totalPrice: number;
   status: 'REQUESTED' | 'REJECTED' | 'APPROVED' | 'PROCESSING' | 'COMPLETED';
   items: ReturnItemResponse[];
 }
 
-// [수정] 백엔드 ReturnItemResponseDto에 맞춘 반품 품목 타입
 interface ReturnItemResponse {
   productId: number;
   productName: string;
@@ -49,7 +49,6 @@ interface ReturnItemResponse {
   subtotalPrice: number;
 }
 
-// 상품 정보 타입
 interface Product {
   productId: number | null;
   productName: string;
@@ -58,18 +57,16 @@ interface Product {
   unitPrice: number;
 }
 
-// 주문 품목 타입
 interface OrderItem {
   productId: number | null;
   productName: string;
-  productCode?: string; // 추가
-  manufacturer?: string; // 추가
+  productCode?: string;
+  manufacturer?: string;
   quantity: number;
   unitPrice: number;
   subtotalPrice: number;
 }
 
-// 주문 정보 타입
 interface Order {
   orderId: number;
   pharmacyName: string;
@@ -79,7 +76,6 @@ interface Order {
   items: OrderItem[];
 }
 
-// 장바구니에 담기는 반품 항목 타입
 interface CartItem {
   key: string;
   orderId: number;
@@ -93,34 +89,31 @@ interface CartItem {
   returnDate: string;
 }
 
-// [추가] 반품 상세 정보를 표시하는 모달 컴포넌트
 interface ReturnDetailModalProps {
   open: boolean;
   onClose: () => void;
   returnDetail: ReturnResponse | null;
 }
 
+// --- 헬퍼 함수 ---
+const getStatusColor = (status: ReturnResponse['status']) => {
+  const colorMap = { REQUESTED: 'blue', APPROVED: 'cyan', PROCESSING: 'gold', COMPLETED: 'green', REJECTED: 'red' };
+  return colorMap[status] || 'default';
+};
+
+const statusTranslations: Record<ReturnResponse['status'], string> = {
+  'REQUESTED': '요청됨',
+  'REJECTED': '거절됨',
+  'APPROVED': '승인됨',
+  'PROCESSING': '처리 중',
+  'COMPLETED': '완료됨',
+};
+
+// --- 상세 정보 모달 컴포넌트 ---
 const ReturnDetailModal: React.FC<ReturnDetailModalProps> = ({ open, onClose, returnDetail }) => {
   if (!returnDetail) return null;
-
-  // 상태 한글 번역 매핑 (모달 내에서 사용)
-  const statusTranslations: Record<ReturnResponse['status'], string> = {
-    'REQUESTED': '요청됨',
-    'REJECTED': '거절됨',
-    'APPROVED': '승인됨',
-    'PROCESSING': '처리 중',
-    'COMPLETED': '완료됨',
-  };
-
   return (
-    <Modal
-      title="반품 상세 정보"
-      open={open}
-      onCancel={onClose}
-      footer={null}
-      width={800}
-    >
-      {/* [수정] Descriptions 컴포넌트를 사용하여 상세 정보 깔끔하게 표시 */}
+    <Modal title="반품 상세 정보" open={open} onCancel={onClose} footer={null} width={800}>
       <Descriptions bordered column={2} size="small">
         <Descriptions.Item label="반품 ID">{returnDetail.returnId}</Descriptions.Item>
         <Descriptions.Item label="약국명">{returnDetail.pharmacyName}</Descriptions.Item>
@@ -131,47 +124,15 @@ const ReturnDetailModal: React.FC<ReturnDetailModalProps> = ({ open, onClose, re
           <Tag color={getStatusColor(returnDetail.status)}>{statusTranslations[returnDetail.status] || returnDetail.status}</Tag>
         </Descriptions.Item>
       </Descriptions>
-
       <Typography.Title level={4} style={{ marginTop: 24, marginBottom: 16 }}>반품 품목</Typography.Title>
-      <Table
-        dataSource={returnDetail.items}
-        columns={[
-          { title: '제품명', dataIndex: 'productName', key: 'productName' },
-          { title: '제조사', dataIndex: 'manufacturer', key: 'manufacturer' },
-          { title: '수량', dataIndex: 'quantity', key: 'quantity' },
-          { title: '단가', dataIndex: 'unitPrice', key: 'unitPrice', render: (val) => `${val.toLocaleString()}원` },
-          { title: '소계', dataIndex: 'subtotalPrice', key: 'subtotalPrice', render: (val) => `${val.toLocaleString()}원` },
-        ]}
-        pagination={false}
-        rowKey="productId"
-        size="small"
-      />
+      <Table dataSource={returnDetail.items} columns={[{ title: '제품명', dataIndex: 'productName' }, { title: '제조사', dataIndex: 'manufacturer' }, { title: '수량', dataIndex: 'quantity' }, { title: '단가', dataIndex: 'unitPrice', render: (val) => `${val.toLocaleString()}원` }, { title: '소계', dataIndex: 'subtotalPrice', render: (val) => `${val.toLocaleString()}원` }]} pagination={false} rowKey="productId" size="small" />
       <Typography.Title level={4} style={{ marginTop: 24, marginBottom: 16 }}>반품 사유</Typography.Title>
-      <Card style={{ marginBottom: 24 }}>
-        <Typography.Paragraph>{returnDetail.items[0]?.reason || '사유 없음'}</Typography.Paragraph>
-      </Card>
+      <Card><Typography.Paragraph>{returnDetail.items[0]?.reason || '사유 없음'}</Typography.Paragraph></Card>
     </Modal>
   );
 };
 
-// [추가] 상태에 따른 태그 색상 반환 함수 (모달과 페이지에서 공통 사용)
-const getStatusColor = (status: ReturnResponse['status']) => {
-  switch (status) {
-    case 'REQUESTED':
-      return 'blue';
-    case 'APPROVED':
-      return 'cyan';
-    case 'PROCESSING':
-      return 'gold';
-    case 'COMPLETED':
-      return 'green';
-    case 'REJECTED':
-      return 'red';
-    default:
-      return 'default';
-  }
-};
-
+// --- 메인 페이지 컴포넌트 ---
 export default function ReturnRequestPage() {
   const { profile } = useAuthStore();
   const pharmacyProfile = profile as Pharmacy;
@@ -181,216 +142,126 @@ export default function ReturnRequestPage() {
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
   const [productList, setProductList] = useState<Product[]>([]);
   const [currentMaxReturnQuantity, setCurrentMaxReturnQuantity] = useState<number>(1);
-  
   const [modalVisible, setModalVisible] = useState(false);
   const today = new Date().toISOString().slice(0, 10);
-
-  // [추가] 상세 정보 모달 관련 상태
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [selectedReturnDetail, setSelectedReturnDetail] = useState<ReturnResponse | null>(null);
+  const [ordersForModal, setOrdersForModal] = useState<Order[]>([]);
 
+  const [loading, setLoading] = useState({ history: false });
+  const [pagination, setPagination] = useState({ current: 1, pageSize: 5, total: 0 });
 
-  // [수정] 반품 내역을 가져오는 함수 (API 연동 및 응답 구조 변경 반영)
-
-  // NOTE: 현재 백엔드에서 승인 거부 할 경우 사유를 입력하는데, 백엔드에서 해당 사유를 저장하는 로직이 없음
-  // NOTE: 추후 API 기능 추가되면 구현 예정
-  
-  const fetchReturnHistory = useCallback(async () => {
-    if (!pharmacyProfile?.pharmacyId) {
-      return;
-    }
+  const fetchReturnHistory = useCallback(async (page = 1) => {
+    if (!pharmacyProfile?.pharmacyId) return;
+    setLoading(prev => ({ ...prev, history: true }));
     try {
-      // /api/branch/returns 엔드포인트 사용
-      const response = await api.get(`/branch/returns?pharmacyId=${pharmacyProfile.pharmacyId}&status=APPROVED`);
-      if (response.data.success) {
-        // 백엔드 응답 구조에 맞춰 response.data.data를 직접 사용
-        if (response.data.data) { // data 필드가 존재하는지 확인
-          setReturnHistory(response.data.data); // data 필드가 직접 배열을 포함
-        } else {
-          setReturnHistory([]);
-        }
-      } else {
-        message.error(response.data.message || '반품 내역을 불러오는데 실패했습니다.');
-      }
+      const params = {
+        pharmacyId: pharmacyProfile.pharmacyId,
+        page: page - 1,
+        size: pagination.pageSize,
+      };
+      const response = await api.get('/branch/returns', { params });
+      const responseData = response.data || {};
+      setReturnHistory(responseData.data || []);
+      setPagination(prev => ({ ...prev, current: page, total: responseData.totalElements || 0 }));
     } catch (error) {
-      console.error('반품 내역 불러오기 실패:', error);
       message.error('반품 내역을 불러오는 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(prev => ({ ...prev, history: false }));
     }
-  }, [pharmacyProfile]);
+  }, [pharmacyProfile, pagination.pageSize]);
 
-  
-  // [수정] 주문 목록을 가져오는 함수 (API 연동 및 응답 구조 변경 반영)
-  // NOTE: 백엔드 OrderService의 getOrdersByPharmacy 메소드가 status 파라미터를 필수가 아닌 선택적으로 받도록 변경됨
-  // NOTE: 이에 따라 status 파라미터 없이 API를 호출하여 모든 상태의 주문을 가져오도록 함
-  
   const fetchOrders = useCallback(async () => {
-    if (!pharmacyProfile?.pharmacyId) {
-      return;
-    }
+    if (!pharmacyProfile?.pharmacyId) return;
     try {
-      const url = `/orders/branch/orders?pharmacyId=${pharmacyProfile.pharmacyId}`;
-
+      const url = `/orders/branch/orders?pharmacyId=${pharmacyProfile.pharmacyId}&status=APPROVED`;
       const response = await api.get(url);
       if (response.data.success) {
-        const fetchedOrders = response.data.data;
-        setOrdersForModal(fetchedOrders || []);
+        setOrdersForModal(response.data.data || []);
       } else {
         message.error(response.data.message || '주문 목록을 불러오는데 실패했습니다.');
       }
     } catch (error) {
-      console.error('주문 목록 불러오기 실패:', error);
       message.error('주문 목록을 불러오는 중 오류가 발생했습니다.');
     }
   }, [pharmacyProfile]);
 
-  const [ordersForModal, setOrdersForModal] = useState<Order[]>([]);
-
-  // [수정] 컴포넌트 마운트 시 주문 및 반품 내역 조회
   useEffect(() => {
     if (pharmacyProfile?.pharmacyId) {
       fetchOrders();
-      fetchReturnHistory();
+      fetchReturnHistory(1);
     }
   }, [pharmacyProfile, fetchOrders, fetchReturnHistory]);
 
-  // [정리] 선택된 주문 변경 시 폼 필드 초기화
-  useEffect(() => {
-    if (!selectedOrder) {
-      form.setFieldValue('maxReturnQuantity', 1);
-    }
-    form.resetFields(['product', 'quantity', 'reason']);
-  }, [selectedOrder, form]);
-
-  // [정리] 주문번호 선택 모달 열기
-  const handleOrderClick = () => {
-    setModalVisible(true);
-    fetchOrders();
-  };
-
-  // [정리] 주문 선택 핸들러
+  const handleOrderClick = () => { setModalVisible(true); fetchOrders(); };
   const handleOrderSelect = (order: Order) => {
     form.setFieldValue('orderNumber', order.orderId);
-    form.validateFields(['orderNumber']);
     setSelectedOrder(order);
-    setProductList(order.items.filter(item => item.productId !== null).map(item => {
-      const product = {
-        productId: item.productId as number,
-        productName: item.productName,
-        productCode: item.productCode,
-        manufacturer: item.manufacturer,
-        unitPrice: item.unitPrice,
-      };
-      return product;
-    }));
+    const products = order.items
+      .filter(item => item.productId !== null)
+      .map(item => ({ ...item, productId: item.productId!, productCode: item.productCode, manufacturer: item.manufacturer }));
+    setProductList(products);
     form.resetFields(['product', 'quantity', 'reason']);
     setModalVisible(false);
   };
 
-  // [정리] 제품 변경 핸들러
   const handleProductChange = (productId: number) => {
-    const product = productList.find((p) => p.productId === productId) || null;
-    let calculatedMaxQuantity = 1;
-    if (selectedOrder) {
-      const orderedItem = selectedOrder.items.find(item => item.productId === productId);
-      if (orderedItem) {
-        calculatedMaxQuantity = orderedItem.quantity;
-      }
-    }
-    setCurrentMaxReturnQuantity(calculatedMaxQuantity);
-    form.setFieldsValue({
-      unitPrice: product?.unitPrice || '',
-      quantity: null,
-      maxReturnQuantity: calculatedMaxQuantity,
-    });
+    const orderedItem = selectedOrder?.items.find(item => item.productId === productId);
+    const maxQty = orderedItem ? orderedItem.quantity : 1; // Explicitly check if orderedItem exists
+    setCurrentMaxReturnQuantity(maxQty);
+    const product = productList.find(p => p.productId === productId);
+    form.setFieldsValue({ unitPrice: product?.unitPrice || '', quantity: null });
   };
 
-  // [정리] 장바구니에 항목 추가
   const handleAddItem = () => {
-    form.validateFields(['product', 'quantity', 'reason', 'orderNumber'])
-      .then((values) => {
-        if (!selectedOrder) {
-          message.error('주문번호를 먼저 선택해주세요.');
-          return;
-        }
-        const selectedProductInForm = productList.find((p) => p.productId === values.product);
-        if (!selectedProductInForm) {
-          message.error('선택된 제품 정보를 찾을 수 없습니다.');
-          return;
-        }
-        const isDuplicate = items.some(
-          (item) =>
-            item.orderId === selectedOrder.orderId &&
-            item.productId === selectedProductInForm.productId
-        );
-        if (isDuplicate) {
-          message.warning('이미 추가된 반품 항목입니다.');
-          return;
-        }
-
-        const newItem: CartItem = {
-          key: `${selectedOrder.orderId}-${selectedProductInForm.productId}-${Date.now()}`,
-          orderId: selectedOrder.orderId,
-          productId: selectedProductInForm.productId,
-          productName: selectedProductInForm.productName,
-          productCode: selectedProductInForm.productCode,
-          manufacturer: selectedProductInForm.manufacturer,
-          quantity: values.quantity,
-          unitPrice: selectedProductInForm.unitPrice,
-          reason: values.reason,
-          returnDate: today,
-        };
-        setItems([...items, newItem]);
-        message.success('항목이 성공적으로 추가되었습니다.');
-        form.resetFields(['product', 'quantity', 'reason']);
-      })
-      .catch(() => {
-        message.error('필수 입력 항목을 모두 채워주세요.');
-      });
-  };
-
-  // [정리] 장바구니 항목 삭제
-  const handleRemoveItem = (key: string) => {
-    setItems(items.filter((item) => item.key !== key));
-  };
-
-  // [수정] 반품 신청 제출 (API 연동 및 반품 내역 새로고침)
-  const handleSubmit = async () => {
-    if (items.length === 0 || !selectedOrder) {
-      message.warning('반품할 항목을 추가하고 주문을 선택해주세요.');
-      return;
-    }
-
-    try {
-      const returnRequestData = {
-        pharmacyId: pharmacyProfile.pharmacyId,
+    form.validateFields().then(values => {
+      if (!selectedOrder) { message.error('주문번호를 먼저 선택해주세요.'); return; }
+      const product = productList.find(p => p.productId === values.product);
+      if (!product) { message.error('제품 정보를 찾을 수 없습니다.'); return; }
+      if (items.some(item => item.orderId === selectedOrder.orderId && item.productId === product.productId)) {
+        message.warning('이미 추가된 반품 항목입니다.'); return; }
+      const newItem: CartItem = {
+        key: `${selectedOrder.orderId}-${product.productId}`,
         orderId: selectedOrder.orderId,
-        reason: items[0]?.reason || '단순 변심',
-        items: items.map((item) => ({
-          productId: item.productId,
-          quantity: item.quantity,
-          unitPrice: item.unitPrice,
-        })),
+        productId: product.productId!,
+        productName: product.productName,
+        productCode: product.productCode,
+        manufacturer: product.manufacturer,
+        quantity: values.quantity,
+        unitPrice: product.unitPrice,
+        reason: values.reason,
+        returnDate: today,
       };
+      setItems([...items, newItem]);
+      form.resetFields(['product', 'quantity', 'reason']);
+    }).catch(() => message.error('필수 입력 항목을 모두 채워주세요.'));
+  };
 
-      const response = await api.post('/branch/returns', returnRequestData);
+  const handleRemoveItem = (key: string) => setItems(items.filter(item => item.key !== key));
 
+  const handleSubmit = async () => {
+    if (items.length === 0 || !selectedOrder) { message.warning('반품할 항목을 추가해주세요.'); return; }
+    try {
+      const response = await api.post('/branch/returns', { 
+        pharmacyId: pharmacyProfile.pharmacyId, 
+        orderId: selectedOrder.orderId, 
+        reason: items[0].reason, 
+        items: items.map(item => ({ productId: item.productId, quantity: item.quantity, unitPrice: item.unitPrice })) 
+      });
       if (response.data.success) {
         message.success('반품 요청이 성공적으로 제출되었습니다.');
         setItems([]);
         form.resetFields();
         setSelectedOrder(null);
-        fetchReturnHistory();
+        fetchReturnHistory(1);
       } else {
         message.error(response.data.message || '반품 요청에 실패했습니다.');
       }
     } catch (error) {
-      console.error('반품 요청 실패:', error);
-      const errorMessage = (error as any).response?.data?.message || '반품 요청 중 오류가 발생했습니다.';
-      message.error(errorMessage);
+      message.error('반품 요청 중 오류가 발생했습니다.');
     }
   };
 
-  // [추가] 반품 내역 테이블 행 클릭 핸들러 (상세 모달 표시)
   const handleReturnHistoryRowClick = async (record: ReturnResponse) => {
     try {
       const response = await api.get(`/branch/returns/${record.returnId}`);
@@ -401,14 +272,12 @@ export default function ReturnRequestPage() {
         message.error(response.data.message || '반품 상세 정보를 불러오는 데 실패했습니다.');
       }
     } catch (error) {
-      console.error('Error fetching return detail:', error);
       message.error('반품 상세 정보를 불러오는 중 오류가 발생했습니다.');
     }
   };
 
   const totalAmount = items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0);
 
-  // [정리] 장바구니 테이블 컬럼 정의
   const columns: ColumnsType<CartItem> = [
     { title: '신청일', dataIndex: 'returnDate' },
     { title: '제품명', dataIndex: 'productName' },
@@ -416,55 +285,21 @@ export default function ReturnRequestPage() {
     { title: '제조사', dataIndex: 'manufacturer' },
     { title: '반품 수량', dataIndex: 'quantity' },
     { title: '단가', dataIndex: 'unitPrice', render: (val) => `${val.toLocaleString()}원` },
-    {
-      title: '반품 금액',
-      render: (_, record) => `${(record.quantity * record.unitPrice).toLocaleString()}원`,
-    },
+    { title: '반품 금액', render: (_, record) => `${(record.quantity * record.unitPrice).toLocaleString()}원` },
     { title: '반품 사유', dataIndex: 'reason' },
-    {
-      title: '관리',
-      render: (_, record) => (
-        <Button danger onClick={() => handleRemoveItem(record.key)}>
-          삭제
-        </Button>
-      ),
-    },
+    { title: '관리', render: (_, record) => <Button danger onClick={() => handleRemoveItem(record.key)}>삭제</Button> },
   ];
 
-  // [수정] 반품 내역 테이블 컬럼 정의 (API 응답 구조에 맞춤)
   const historyColumns: ColumnsType<ReturnResponse> = [
     { title: '신청일', dataIndex: 'createdAt', render: (text) => new Date(text).toLocaleDateString() },
     { title: '반품번호', dataIndex: 'returnId' },
-    {
-      title: '총 반품 금액',
-      dataIndex: 'totalPrice',
-      render: (val) => `${val.toLocaleString()}원`,
-    },
-    {
-      title: '상태',
-      dataIndex: 'status',
-      render: (status) => <Tag color={getStatusColor(status)}>{statusTranslations[status] || status}</Tag>,
-    },
-    {
-      title: '반품 품목',
-      dataIndex: 'items',
-      render: (items: ReturnItemResponse[]) => (
-        <ul style={{ padding: 0, margin: 0, listStyle: 'none' }}>
-          {items.map((item, index) => (
-            <li key={index}>{item.productName} ({item.quantity}개)</li>
-          ))}
-        </ul>
-      ),
-    },
+    { title: '총 반품 금액', dataIndex: 'totalPrice', render: (val) => `${val.toLocaleString()}원` },
+    { title: '상태', dataIndex: 'status', render: (status) => <Tag color={getStatusColor(status)}>{statusTranslations[status] || status}</Tag> },
+    { title: '반품 품목', dataIndex: 'items', render: (items: ReturnItemResponse[]) => `${items[0]?.productName || ''}${items.length > 1 ? ` 외 ${items.length - 1}건` : ''}` },
   ];
 
-  // [정리] 상태 한글 번역 매핑
-  const statusTranslations: Record<ReturnResponse['status'], string> = {
-    'REQUESTED': '요청됨',
-    'REJECTED': '거절됨',
-    'APPROVED': '승인됨',
-    'PROCESSING': '처리 중',
-    'COMPLETED': '완료됨',
+  const handleTableChange: TableProps<ReturnResponse>['onChange'] = (newPagination) => {
+    fetchReturnHistory(newPagination.current!);
   };
 
   return (
@@ -473,169 +308,77 @@ export default function ReturnRequestPage() {
       <Form form={form} layout="vertical">
         <Row gutter={16}>
           <Col span={6}>
-            <Form.Item
-              name="orderNumber"
-              label={<span style={{ color: 'red' }}>* 주문번호</span>}
-              rules={[{ required: true, message: '주문번호를 선택해주세요.' }]}
-            >
+            <Form.Item name="orderNumber" label={<span style={{ color: 'red' }}>* 주문번호</span>} rules={[{ required: true, message: '주문번호를 선택해주세요.' }]}>
               <Input readOnly onClick={handleOrderClick} placeholder="주문번호 선택" />
             </Form.Item>
           </Col>
         </Row>
         <Row gutter={16} align="bottom">
           <Col span={4}>
-            <Form.Item
-              name="product"
-              label={<span style={{ color: 'red' }}>* 제품명</span>}
-              rules={[{ required: true, message: '제품을 선택해주세요.' }]}
-            >
-              <Select
-                placeholder="제품 선택"
-                onChange={(value) => {
-                  form.setFieldValue('product', value);
-                  handleProductChange(value);
-                }}
-                value={form.getFieldValue('product')}
-                disabled={!productList.length}
-              >
-                {productList.map((p) => (
-                  <Option key={p.productId} value={p.productId}>
-                    {p.productName || '이름 없음'}
-                  </Option>
-                ))}
+            <Form.Item name="product" label={<span style={{ color: 'red' }}>* 제품명</span>} rules={[{ required: true, message: '제품을 선택해주세요.' }]}>
+              <Select placeholder="제품 선택" onChange={handleProductChange} disabled={!selectedOrder}>
+                {productList.map((p, index) => (<Option key={p.productId !== null ? p.productId : `product-${index}`} value={p.productId!}>{p.productName}</Option>))}
               </Select>
             </Form.Item>
           </Col>
           <Col span={4}>
-            <Form.Item
-              name="quantity"
-              label={<span style={{ color: 'red' }}>* 반품 수량</span>}
-              rules={[
-                { required: true, message: '반품 수량 입력.' },
-                ({ getFieldValue }) => ({
-                  validator(_, value) {
-                    if (!value || value <= currentMaxReturnQuantity) {
-                      return Promise.resolve();
-                    }
-                    return Promise.reject(new Error(`반품 수량은 주문 수량(${currentMaxReturnQuantity}개)을 초과할 수 없습니다.`));
-                  },
-                }),
-              ]}
-            >
-              <InputNumber
-                min={1}
-                max={currentMaxReturnQuantity}
-                style={{ width: '100%' }}
-                placeholder={form.getFieldValue('product') ? `주문 수량: ${currentMaxReturnQuantity || 0}개` : '반품 수량 입력'}
-              />
+            <Form.Item name="quantity" label={<span style={{ color: 'red' }}>* 반품 수량</span>} rules={[{ required: true, message: '반품 수량 입력.' }, ({ getFieldValue }) => ({ validator(_, value) { if (!value || value <= currentMaxReturnQuantity) { return Promise.resolve(); } return Promise.reject(new Error(`반품 수량은 주문 수량(${currentMaxReturnQuantity}개)을 초과할 수 없습니다.`)); } })]}>
+              <InputNumber min={1} max={currentMaxReturnQuantity} style={{ width: '100%' }} placeholder={`주문 수량: ${currentMaxReturnQuantity || 0}개`} />
             </Form.Item>
           </Col>
           <Col span={4}>
             <Form.Item label="단가">
-              <Input
-                disabled
-                value={
-                  productList.find(p => p.productId === form.getFieldValue('product'))?.unitPrice
-                    ? `${productList.find(p => p.productId === form.getFieldValue('product'))?.unitPrice.toLocaleString()}원`
-                    : ''
-                }
-              />
+              <Input disabled value={productList.find(p => p.productId === form.getFieldValue('product'))?.unitPrice ? `${productList.find(p => p.productId === form.getFieldValue('product'))?.unitPrice.toLocaleString()}원` : ''} />
             </Form.Item>
           </Col>
           <Col span={6}>
-            <Form.Item
-              name="reason"
-              label={<span style={{ color: 'red' }}>* 반품 사유</span>}
-              rules={[{ required: true, message: '반품 사유 입력.' }]}
-            >
+            <Form.Item name="reason" label={<span style={{ color: 'red' }}>* 반품 사유</span>} rules={[{ required: true, message: '반품 사유 입력.' }]}>
               <Input.TextArea placeholder="반품 사유 입력" autoSize={{ minRows: 1, maxRows: 4 }} />
             </Form.Item>
           </Col>
-          <Col>
-            <Form.Item>
-              <Button type="primary" onClick={handleAddItem} style={{ marginTop: 30 }}>
-                항목 추가
-              </Button>
-            </Form.Item>
-          </Col>
+          <Col><Form.Item><Button type="primary" onClick={handleAddItem} style={{ marginTop: 30 }}>항목 추가</Button></Form.Item></Col>
         </Row>
       </Form>
 
-      <Table
-        columns={columns}
-        dataSource={items}
-        pagination={false}
-        style={{ marginTop: 16 }}
-        rowKey="key"
-      />
-      <div style={{ textAlign: 'right', marginTop: 12 }}>
-        총 반품 금액: <strong>{totalAmount.toLocaleString()}원</strong>
-      </div>
-      <div style={{ textAlign: 'right', marginTop: 12 }}>
-        <Button type="primary" onClick={handleSubmit}>
-          반품 신청
-        </Button>
-      </div>
+      <Table columns={columns} dataSource={items} pagination={false} style={{ marginTop: 16 }} rowKey="key" />
+      <div style={{ textAlign: 'right', marginTop: 12 }}>총 반품 금액: <strong>{totalAmount.toLocaleString()}원</strong></div>
+      <div style={{ textAlign: 'right', marginTop: 12 }}><Button type="primary" onClick={handleSubmit}>반품 신청</Button></div>
 
-      <Card title="반품 진행 현황" style={{ marginTop: 48 }}>
+      <Card title={
+        <Row justify="space-between" align="middle">
+          <Col><Title level={4} style={{ margin: 0 }}>반품 진행 현황</Title></Col>
+          <Col>
+            <Button icon={<ReloadOutlined />} onClick={() => fetchReturnHistory(pagination.current)} loading={loading.history}>
+              새로고침
+            </Button>
+          </Col>
+        </Row>
+      } style={{ marginTop: 48 }}>
         <Table
           columns={historyColumns}
           dataSource={returnHistory}
-          pagination={{ pageSize: 5 }}
-          rowKey={(record) => record.returnId !== null && record.returnId !== undefined ? record.returnId : `return-${record.createdAt}-${record.pharmacyId}`}
-          onRow={(record) => {
-            return {
-              onClick: () => {
-
-                handleReturnHistoryRowClick(record);
-              },
-            };
-          }}
+          rowKey="returnId"
+          pagination={pagination}
+          loading={loading.history}
+          onChange={handleTableChange}
+          onRow={(record) => ({ onClick: () => handleReturnHistoryRowClick(record) })}
         />
       </Card>
 
-      <Modal
-        title="주문번호 선택"
-        open={modalVisible}
-        onCancel={() => setModalVisible(false)}
-        footer={null}
-      >
+      <Modal title="주문번호 선택" open={modalVisible} onCancel={() => setModalVisible(false)} footer={null}>
         {ordersForModal.length > 0 ? (
-          ordersForModal.map((order, index) => (
-            <Card
-              key={
-                order.orderId !== null && order.orderId !== undefined
-                  ? order.orderId
-                  : `order-${index}`
-              }
-              hoverable
-              onClick={() => handleOrderSelect(order)}
-              style={{ marginBottom: 16 }}
-            >
-              <p>
-                <strong>주문번호:</strong> {order.orderId}
-              </p>
-              <p>
-                <strong>지점명:</strong> {order.pharmacyName || '이름 없음'}
-              </p>
-              <p>
-                <strong>요청일자:</strong> {new Date(order.createdAt).toLocaleDateString()}
-              </p>
-              <p>
-                <strong>총 금액:</strong> {order.totalPrice.toLocaleString()}원
-              </p>
+          ordersForModal.map(order => (
+            <Card key={order.orderId} hoverable onClick={() => handleOrderSelect(order)} style={{ marginBottom: 16 }}>
+              <p><strong>주문번호:</strong> {order.orderId}</p>
+              <p><strong>지점명:</strong> {order.pharmacyName}</p>
+              <p><strong>요청일자:</strong> {new Date(order.createdAt).toLocaleDateString()}</p>
+              <p><strong>총 금액:</strong> {order.totalPrice.toLocaleString()}원</p>
             </Card>
           ))
-        ) : (
-          <p>주문 내역이 없습니다.</p>
-        )}
+        ) : <p>주문 내역이 없습니다.</p>}
       </Modal>
 
-      <ReturnDetailModal
-        open={isDetailModalOpen}
-        onClose={() => setIsDetailModalOpen(false)}
-        returnDetail={selectedReturnDetail}
-      />
+      <ReturnDetailModal open={isDetailModalOpen} onClose={() => setIsDetailModalOpen(false)} returnDetail={selectedReturnDetail} />
     </div>
   );
 }

--- a/frontend/src/pages/HQ/OrderManagementPage.tsx
+++ b/frontend/src/pages/HQ/OrderManagementPage.tsx
@@ -1,4 +1,4 @@
-// 필요한 React Hooks 및 antd 컴포넌트들을 가져옵니다.
+
 import {
   Button,
   Cascader,
@@ -9,26 +9,24 @@ import {
   Layout,
   Modal,
   Row,
+  Select,
   Space,
   Table,
   Tag,
   Typography,
   message,
 } from 'antd';
-// [변경] useCallback 훅 추가 및 api 모듈 임포트
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-
-// antd에서 필요한 타입들을 가져옵니다.
-import type { CascaderProps, GetProp, TableColumnsType, TableProps } from 'antd';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import type { TableProps } from 'antd';
 import { instance } from '../../api/api';
 
-// [변경] 백엔드 API 응답(OrderResponse, OrderItemResponse)에 따른 타입 정의
+// --- 타입 정의 ---
 interface OrderItem {
   productName: string;
   quantity: number;
   unitPrice: number;
   subtotalPrice: number;
-  productId: number; // [추가] 제품 ID
+  productId: number;
 }
 
 interface Order {
@@ -40,384 +38,229 @@ interface Order {
   items: OrderItem[];
 }
 
-const { Content } = Layout; // Layout에서 Content 컴포넌트를 사용합니다.
-const { Text } = Typography; // Typography에서 Text 컴포넌트를 사용합니다.
-
-// Ant Design Table의 onChange 이벤트 핸들러 타입을 정의합니다.
-type OnChange<T> = NonNullable<TableProps<T>['onChange']>;
-
-// 배열 타입에서 단일 요소의 타입을 추출합니다.
-type GetSingle<T> = T extends (infer U)[] ? U : never;
-
-// 정렬 정보를 담는 타입을 정의합니다.
-type Sorts = GetSingle<Parameters<OnChange<OrderTableDataType>>[2]>;
-
-// Cascader의 옵션 타입을 가져옵니다.
-type DefaultOptionType = GetProp<CascaderProps, 'options'>[number];
-
-// [변경] OrderTableDataType 인터페이스 수정 (pharmacyName은 Order 인터페이스에 포함됨)
 interface OrderTableDataType extends Order {
-  key: React.Key; // 테이블 행의 고유 키
-  productSummary: string; // 주문 상품 요약
+  key: React.Key;
+  productSummary: string;
 }
 
-// 지역 선택 Cascader에서 사용할 옵션의 타입을 정의합니다.
 interface Option {
-  value: string; // 옵션의 값
-  label: string; // 옵션의 레이블
-  children?: Option[]; // 하위 옵션
+  value: string;
+  label: string;
+  children?: Option[];
 }
 
-// 지역 선택 옵션 데이터입니다.
-const options: Option[] = [
-  {
-    value: '충남충북',
-    label: '충남충북',
-    children: [
-      { value: '천안', label: '천안' },
-      { value: '대전', label: '대전' },
-      { value: '청주', label: '청주' },
-    ],
-  },
+// --- 상수 및 헬퍼 함수 ---
+const { Content } = Layout;
+const { Text } = Typography;
+
+const geoOptions: Option[] = [
+    {
+        value: '충남충북',
+        label: '충남충북',
+        children: [
+          { value: '천안', label: '천안' },
+          { value: '대전', label: '대전' },
+          { value: '청주', label: '청주' },
+          { value: 'test1', label: 'test1' },
+          { value: 'test2', label: 'test2' },
+        ],
+    },
 ];
 
-// Cascader에서 검색 기능을 사용할 때 적용될 필터 함수입니다.
-const filter = (inputValue: string, path: DefaultOptionType[]) =>
-  path.some(
-    (option) => (option.label as string).toLowerCase().indexOf(inputValue.toLowerCase()) > -1,
-  );
+// TODO : 태그 관련 논의 필요함
+const statusOptions = [
+  { value: 'REQUESTED', label: '승인 대기' },
+  { value: 'APPROVED', label: '승인 완료' },
+  { value: 'PROCESSING', label: '처리 중' },
+  { value: 'SHIPPING', label: '배송 중' },
+  { value: 'COMPLETED', label: '완료' },
+  { value: 'CANCELED', label: '취소' },
+];
 
-// 주문 상태에 따라 다른 색상의 태그를 반환하는 함수입니다.
 const getStatusTag = (status: Order['status']) => {
-  switch (status) {
-    case 'REQUESTED':
-      return <Tag color="blue">승인 대기</Tag>;
-    case 'APPROVED':
-      return <Tag color="green">승인 완료</Tag>;
-    case 'PROCESSING':
-      return <Tag color="purple">처리 중</Tag>;
-    case 'SHIPPING':
-      return <Tag color="orange">배송 중</Tag>;
-    case 'COMPLETED':
-      return <Tag color="gold">완료</Tag>;
-    case 'CANCELED':
-      return <Tag color="red">취소</Tag>;
-    default:
-      return <Tag>{status}</Tag>;
-  }
+    const option = statusOptions.find(o => o.value === status);
+    const colorMap = {
+        REQUESTED: 'blue',
+        APPROVED: 'green',
+        PROCESSING: 'purple',
+        SHIPPING: 'orange',
+        COMPLETED: 'gold',
+        CANCELED: 'red',
+    };
+    return <Tag color={colorMap[status]}>{option ? option.label : status}</Tag>;
 };
 
-// 본사의 발주 관리 페이지 컴포넌트입니다.
-export default function OrderManagementPage() {
-  const [loadings, setLoadings] = useState<boolean[]>([]); // 버튼 로딩 상태를 관리합니다.
-  const [sortedInfo, setSortedInfo] = useState<Sorts>({}); // 테이블 정렬 상태를 관리합니다.
-  // [변경] 주문 데이터 상태 초기값을 빈 배열로 변경 (API에서 가져옴)
-  const [orders, setOrders] = useState<OrderTableDataType[]>([]); // 주문 데이터를 관리합니다.
-  // [변경] 필터링된 주문 데이터 상태 초기값을 빈 배열로 변경
-  const [filteredOrders, setFilteredOrders] = useState<OrderTableDataType[]>([]); // 필터링된 주문 데이터를 관리합니다.
-  // [변경] 주문 데이터 로딩 상태 추가
-  const [loadingOrders, setLoadingOrders] = useState<boolean>(true); // 주문 데이터 로딩 상태
-  // [변경] 에러 상태 추가
-  const [selectedOrder, setSelectedOrder] = useState<OrderTableDataType | null>(null); // 사용자가 선택한 주문의 상세 정보를 관리합니다.
-  const [modalVisible, setModalVisible] = useState(false); // 상세 정보 모달의 표시 여부를 관리합니다.
-  const [form] = Form.useForm(); // Ant Design의 Form 인스턴스를 생성합니다.
 
+// --- 컴포넌트 ---
+export default function OrderManagementPage() {
+  const [orders, setOrders] = useState<OrderTableDataType[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [pagination, setPagination] = useState({ current: 1, pageSize: 6, total: 0 });
+  const [filters, setFilters] = useState<Record<string, any>>({});
+  
+  const [selectedOrder, setSelectedOrder] = useState<OrderTableDataType | null>(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  
+  const [form] = Form.useForm();
   const [messageApi, contextHolder] = message.useMessage();
 
-  // [변경] 주문 데이터를 API에서 가져오는 함수 (useCallback으로 메모이제이션)
-  const fetchOrders = useCallback(async () => {
+  const fetchOrders = useCallback(async (page: number, currentFilters: Record<string, any>) => {
+    setLoading(true);
     try {
-      setLoadingOrders(true);
+      const { branch, date, status } = currentFilters;
+      const pharmacyName = Array.isArray(branch) && branch.length > 0 ? branch[branch.length - 1] : undefined;
+      
+      const params = {
+        page: page - 1,
+        size: pagination.pageSize,
+        pharmacyName,
+        status,
+        // TODO: 백엔드에서 날짜 필터링 지원 시 추가
+        // startDate: date ? date[0].format('YYYY-MM-DD') : undefined,
+        // endDate: date ? date[1].format('YYYY-MM-DD') : undefined,
+      };
 
-      const response = await instance.get<Order[]>('/admin/orders'); // admin/orders 를 통해 모든 발주요청 불러와서 저장
-      console.log(' 주문데이터 목록 응답 ', response.data);
-      if (response.data.length >= 1) {
-        // 주문 목록에 하나라도 들어 있을 경우
-        messageApi.success('목록이 성공적으로 불러와졌습니다!');
-        const fetchedOrders = response.data.map((order: Order) => ({
-          ...order,
-          key: order.orderId,
-          productSummary:
-            order.items.length > 0
-              ? `${order.items[0].productName}${
-                  order.items.length > 1 ? ` 외 ${order.items.length - 1}건` : ''
-                }`
-              : '주문 항목 없음',
-        }));
+      // [수정] API 호출 주소 변경 및 응답 데이터 안정성 강화
+      const response = await instance.get('/orders/admin/orders', { params });
+      const responseData = response.data || {};
+      const orderList = responseData.data || [];
+      const totalElements = responseData.totalElements || 0;
 
-        setOrders(fetchedOrders);
-        setFilteredOrders(fetchedOrders); // 모든 주문을 필터링된 주문으로 초기 설정
-      }
-    } catch (e: any) {
+      const fetchedOrders = orderList.map((order: Order) => ({
+        ...order,
+        key: order.orderId,
+        productSummary:
+          order.items.length > 0
+            ? `${order.items[0].productName}${order.items.length > 1 ? ` 외 ${order.items.length - 1}건` : ''}`
+            : '주문 항목 없음',
+      }));
+
+      setOrders(fetchedOrders);
+      setPagination(prev => ({ ...prev, current: page, total: totalElements }));
+
+    } catch (e) {
       console.error('발주 목록 불러오기 실패:', e);
-      messageApi.error('주문 데이터를 불러오는 데 실패했습니다.'); // 발주 목록 불러오기 실패했을 경우
+      messageApi.error('주문 데이터를 불러오는 데 실패했습니다.');
     } finally {
-      setLoadingOrders(false);
+      setLoading(false);
     }
-  }, [setOrders, setFilteredOrders, setLoadingOrders, messageApi]);
+  }, [pagination.pageSize, messageApi]);
 
-  // [변경] 컴포넌트 마운트 시 fetchOrders 호출
   useEffect(() => {
-    fetchOrders();
-  }, [fetchOrders]);
+    fetchOrders(1, {});
+  }, []);
 
-  // 테이블의 정렬 기능이 변경될 때 호출되는 핸들러입니다.
-  const handleSort: OnChange<OrderTableDataType> = (__, _, sorter) => {
-    setSortedInfo(sorter as Sorts);
+  const handleTableChange: TableProps<OrderTableDataType>['onChange'] = (newPagination) => {
+    fetchOrders(newPagination.current!, filters);
+  };
+  
+  const handleFilterSearch = () => {
+    const formValues = form.getFieldsValue();
+    setFilters(formValues);
+    fetchOrders(1, formValues);
   };
 
-  // 테이블의 특정 행이 클릭될 때 호출되는 핸들러입니다.
-  const handleRowClick = (record: OrderTableDataType) => {
-    setSelectedOrder(record); // 선택된 주문 정보를 상태에 저장합니다.
-    setModalVisible(true); // 모달을 표시합니다.
+  const handleFilterReset = () => {
+    form.resetFields();
+    setFilters({});
+    fetchOrders(1, {});
   };
 
-  // [변경] 주문 상태 업데이트 핸들러 (API 호출 포함)
-  // TODO: API 에 상태변경 함수 또는 파트가 있어야 함
   const handleStatusUpdate = async (orderId: number, newStatus: Order['status']) => {
     try {
-      // [변경] API 엔드포인트에 따라 조건부 호출
       if (newStatus === 'APPROVED') {
         await instance.post(`/orders/${orderId}/approve`);
       } else if (newStatus === 'CANCELED') {
         await instance.patch(`/orders/${orderId}/reject`);
-      } else {
-        // 다른 상태 변경이 필요한 경우 여기에 추가
-        await instance.patch(`/orders/${orderId}`, { status: newStatus });
       }
-
-      // API 호출 성공 시에만 프론트엔드 상태 업데이트
-      const updateOrder = (order: OrderTableDataType) =>
-        order.orderId === orderId ? { ...order, status: newStatus } : order;
-
-      const newOrders = orders.map(updateOrder);
-      const newFilteredOrders = filteredOrders.map(updateOrder);
-
-      setOrders(newOrders); // 전체 주문 목록을 업데이트합니다.
-      setFilteredOrders(newFilteredOrders); // 필터링된 주문 목록도 업데이트합니다.
-
-      // 현재 모달에 표시된 주문의 상태도 업데이트합니다.
-      if (selectedOrder?.orderId === orderId) {
-        setSelectedOrder({
-          ...selectedOrder,
-          status: newStatus,
-        });
-      }
+      messageApi.success('상태가 변경되었습니다.');
+      fetchOrders(pagination.current, filters); // 목록 새로고침
     } catch (error) {
       console.error('주문 상태 업데이트 실패:', error);
-      // 에러 처리 로직 (예: 사용자에게 알림)
+      messageApi.error('상태 변경에 실패했습니다.');
     }
   };
 
-  // [변경] '발주 조회' 버튼 클릭 시 fetchOrders 호출 (백엔드 필터링 가정)
-  // TODO: Form 옵션에 따른 필터링 검색 기능이 백엔드 API에 추가되어야 함
-  // NOTE :  현재 방식은 페이지 시작할 때, api로부터 전체 데이터를 받아와서 프론트에서 필터링한 결과를 보여주는 방식
-  // NOTE :  나중에 백엔드에서 필터링된 결과 api 호출 방식으로 변경되면 수정 예정
-  const handleFilterSearch = () => {
-    const { branch, date } = form.getFieldsValue(); // 폼에서 현재 값들을 가져옵니다. ( 지점명, 기간 )
-    const selectedBranch =
-      Array.isArray(branch) && branch.length > 0 ? branch[branch.length - 1] : null;
-    const [startDate, endDate] = date ?? [null, null];
-
-    const filtered = orders.filter((order) => {
-      const matchBranch = !selectedBranch || order.pharmacyName.includes(selectedBranch);
-      const orderDate = new Date(order.createdAt);
-      const matchDate =
-        !startDate ||
-        !endDate ||
-        (orderDate >= startDate.toDate() && orderDate <= endDate.toDate());
-      return matchBranch && matchDate;
-    });
-
-    setFilteredOrders(filtered); // 필터링된 결과를 상태에 적용합니다。
+  const handleRowClick = (record: OrderTableDataType) => {
+    setSelectedOrder(record);
+    setModalVisible(true);
   };
 
-  // 버튼 클릭 시 로딩 효과를 주는 핸들러입니다.
-  const enterLoading = (index: number) => {
-    setLoadings((prev) => {
-      const newLoadings = [...prev];
-      newLoadings[index] = true;
-      return newLoadings;
-    });
-
-    // 1.5초 후 로딩 상태를 해제합니다.
-    setTimeout(() => {
-      setLoadings((prev) => {
-        const newLoadings = [...prev];
-        newLoadings[index] = false;
-        return newLoadings;
-      });
-    }, 1500);
-  };
-
-  // 주문 목록을 표시할 테이블의 컬럼 정의입니다.
-  const columns: TableColumnsType<OrderTableDataType> = [
-    // [변경] dataIndex를 'id'에서 'orderId'로 변경
-    { title: '주문번호', dataIndex: 'orderId', key: 'orderId', width: 100, ellipsis: true },
-    {
-      title: '지점',
-      dataIndex: 'pharmacyName',
-      key: 'pharmacyName',
-      width: 120,
-      sorter: (a, b) => a.pharmacyName.localeCompare(b.pharmacyName), // 이름순 정렬
-      sortOrder: sortedInfo.columnKey === 'pharmacyName' ? sortedInfo.order : null,
-      ellipsis: true,
-    },
-    {
-      title: '요청일자',
-      dataIndex: 'createdAt',
-      key: 'createdAt',
-      width: 150,
-      render: (text) => new Date(text).toLocaleDateString(), // 날짜 형식으로 표시
-      sorter: (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(), // 날짜순 정렬
-      sortOrder: sortedInfo.columnKey === 'createdAt' ? sortedInfo.order : null,
-      ellipsis: true,
-    },
-    {
-      title: '의약품',
-      dataIndex: 'productSummary',
-      key: 'productSummary',
-      width: 200,
-      ellipsis: true,
-    },
-    {
-      title: '주문 금액',
-      dataIndex: 'totalPrice',
-      key: 'totalPrice',
-      width: 120,
-      render: (value) => `${value.toLocaleString()}원`, // 통화 형식으로 표시
-      sorter: (a, b) => a.totalPrice - b.totalPrice, // 금액순 정렬
-      sortOrder: sortedInfo.columnKey === 'totalPrice' ? sortedInfo.order : null,
-    },
-    {
-      title: '상태',
-      dataIndex: 'status',
-      key: 'status',
-      width: 100,
-      // 상태가 'REQUESTED'일 경우 승인 버튼을, 아닐 경우 상태 태그를 표시합니다.
-      render: (status: Order['status'], record) =>
+  const columns: TableProps<OrderTableDataType>['columns'] = [
+    { title: '주문번호', dataIndex: 'orderId', key: 'orderId', width: 100 },
+    { title: '지점', dataIndex: 'pharmacyName', key: 'pharmacyName', width: 120 },
+    { title: '요청일자', dataIndex: 'createdAt', key: 'createdAt', width: 150, render: (text) => new Date(text).toLocaleDateString() },
+    { title: '의약품', dataIndex: 'productSummary', key: 'productSummary', width: 200 },
+    { title: '주문 금액', dataIndex: 'totalPrice', key: 'totalPrice', width: 120, render: (v) => `${v.toLocaleString()}원` },
+    { title: '상태', dataIndex: 'status', key: 'status', width: 100, render: (status: Order['status'], record) =>
         status === 'REQUESTED' ? (
-          <Button
-            type="primary"
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation(); // 행 클릭 이벤트 전파 방지
-              // [변경] record.id에서 record.orderId로 변경
-              handleStatusUpdate(record.orderId, 'APPROVED');
-            }}
-          >
+          <Button type="primary" size="small" onClick={(e) => { e.stopPropagation(); handleStatusUpdate(record.orderId, 'APPROVED'); }}>
             승인
           </Button>
         ) : (
-          getStatusTag(status) // 상태를 태그로 표시
+          getStatusTag(status)
         ),
     },
   ];
-
-  // 선택된 주문의 상세 품목 정보를 계산합니다. (useMemo로 성능 최적화)
-  const selectedOrderItems = useMemo(() => {
-    if (!selectedOrder) return [];
-    // [변경] selectedOrder.items를 직접 반환하도록 수정 (API 응답에 items 포함)
-    return selectedOrder.items; // 선택된 주문의 items 배열을 직접 반환
-  }, [selectedOrder]);
 
   return (
     <>
       {contextHolder}
       <Content style={{ margin: '24px', padding: '24px' }}>
-        {/* 페이지 제목 */}
         <Row justify="space-between" align="middle" style={{ marginBottom: '30px' }}>
           <Col>
-            <Text strong style={{ fontSize: '30px' }}>
-              발주 조회/승인
-            </Text>
+            <Text strong style={{ fontSize: '30px' }}>발주 조회/승인</Text>
           </Col>
         </Row>
 
-        {/* 필터링 옵션 폼 */}
-        <Form layout="vertical" form={form}>
+        <Form layout="vertical" form={form} onFinish={handleFilterSearch}>
           <Row justify="space-between" style={{ padding: '5px 50px' }}>
             <Space>
-              <Col>
-                <Form.Item label="지점명" name="branch">
-                  <Cascader options={options} placeholder="지역 선택" showSearch={{ filter }} />
-                </Form.Item>
-              </Col>
-              <Col>
-                <Form.Item label="기간" name="date">
-                  <DatePicker.RangePicker
-                    placeholder={['시작일', '종료일']}
-                    style={{ width: 400 }}
-                  />
-                </Form.Item>
-              </Col>
-            </Space>
-            <Col>
-              <Form.Item label=" ">
-                <Button
-                  onClick={() => {
-                    form.resetFields(); // 폼 필드 초기화
-                    setFilteredOrders(orders); // 필터링된 목록을 전체 목록으로 복원
-                  }}
-                >
-                  옵션 초기화
-                </Button>
-                <Button
-                  type="primary"
-                  loading={loadings[0]}
-                  onClick={() => {
-                    enterLoading(0);
-                    handleFilterSearch();
-                  }}
-                  style={{ marginLeft: 8 }}
-                >
-                  발주 조회
-                </Button>
+              <Form.Item label="지점명" name="branch">
+                <Cascader options={geoOptions} placeholder="지역 선택" />
               </Form.Item>
-            </Col>
+              <Form.Item label="상태" name="status">
+                <Select allowClear options={statusOptions} placeholder="상태 선택" style={{ width: 150 }} />
+              </Form.Item>
+              <Form.Item label="기간" name="date">
+                <DatePicker.RangePicker placeholder={['시작일', '종료일']} style={{ width: 400 }} />
+              </Form.Item>
+            </Space>
+            <Form.Item label=" ">
+              <Button onClick={handleFilterReset}>옵션 초기화</Button>
+              <Button type="primary" htmlType="submit" style={{ marginLeft: 8 }}>발주 조회</Button>
+            </Form.Item>
           </Row>
         </Form>
 
-        {/* 주문 목록 테이블 */}
         <Row justify="center" style={{ marginTop: 20 }}>
           <Col span={22}>
-            <Table<OrderTableDataType>
+            <Table
               columns={columns}
-              dataSource={filteredOrders}
-              onChange={handleSort}
-              pagination={{ position: ['bottomCenter'], pageSize: 6 }} // 페이지네이션 설정
-              onRow={(record) => ({ onClick: () => handleRowClick(record) })} // 행 클릭 이벤트
-              // [변경] rowKey를 'id'에서 'orderId'로 변경
+              dataSource={orders}
+              pagination={pagination}
+              loading={loading}
+              onChange={handleTableChange}
+              onRow={(record) => ({ onClick: () => handleRowClick(record) })}
               rowKey="orderId"
-              // [변경] 로딩 상태 추가
-              loading={loadingOrders}
             />
           </Col>
         </Row>
 
-        {/* 주문 상세 정보 모달 */}
         <Modal
           title="발주 상세 정보"
           open={modalVisible}
           closable={false}
           onCancel={() => setModalVisible(false)}
           footer={[
-            <Button key="close" onClick={() => setModalVisible(false)}>
-              닫기
-            </Button>,
-            // 상태가 'REQUESTED'일 때만 승인 버튼을 표시합니다.
+            <Button key="close" onClick={() => setModalVisible(false)}>닫기</Button>,
             selectedOrder?.status === 'REQUESTED' && (
-              <Button
-                key="approve"
-                type="primary"
-                onClick={() => {
+              <Button key="approve" type="primary" onClick={() => {
                   if (selectedOrder) {
-                    // [변경] selectedOrder.id에서 selectedOrder.orderId로 변경
                     handleStatusUpdate(selectedOrder.orderId, 'APPROVED');
                     setModalVisible(false);
                   }
-                }}
-              >
+              }}>
                 승인
               </Button>
             ),
@@ -426,50 +269,26 @@ export default function OrderManagementPage() {
         >
           {selectedOrder && (
             <Descriptions bordered column={2} size="middle">
-              {/* [변경] dataIndex를 'id'에서 'orderId'로 변경 */}
-              <Descriptions.Item label="주문번호" span={1}>
-                {selectedOrder.orderId}
-              </Descriptions.Item>
-              <Descriptions.Item label="지점명" span={1}>
-                {selectedOrder.pharmacyName}
-              </Descriptions.Item>
-              <Descriptions.Item label="요청일자" span={1}>
-                {new Date(selectedOrder.createdAt).toLocaleString()}
-              </Descriptions.Item>
-              {/* [변경] 최종 수정일 항목 제거 (백엔드 DTO에 없음) */}
-              <Descriptions.Item label="상태" span={2}>
-                {getStatusTag(selectedOrder.status)}
-              </Descriptions.Item>
+              <Descriptions.Item label="주문번호" span={1}>{selectedOrder.orderId}</Descriptions.Item>
+              <Descriptions.Item label="지점명" span={1}>{selectedOrder.pharmacyName}</Descriptions.Item>
+              <Descriptions.Item label="요청일자" span={1}>{new Date(selectedOrder.createdAt).toLocaleString()}</Descriptions.Item>
+              <Descriptions.Item label="상태" span={2}>{getStatusTag(selectedOrder.status)}</Descriptions.Item>
               <Descriptions.Item label="주문 항목" span={2}>
-                {/* 주문 상세 품목 테이블 */}
                 <Table
-                  dataSource={selectedOrderItems} // 선택된 행에 대한 제품 정보만
+                  dataSource={selectedOrder.items}
                   columns={[
                     { title: '제품명', dataIndex: 'productName', key: 'productName' },
                     { title: '수량', dataIndex: 'quantity', key: 'quantity' },
-                    {
-                      title: '단가',
-                      dataIndex: 'unitPrice',
-                      key: 'unitPrice',
-                      render: (v) => `${v.toLocaleString()}원`,
-                    },
-                    {
-                      title: '소계',
-                      dataIndex: 'subtotalPrice',
-                      key: 'subtotalPrice',
-                      render: (v) => `${v.toLocaleString()}원`,
-                    },
+                    { title: '단가', dataIndex: 'unitPrice', key: 'unitPrice', render: (v) => `${v.toLocaleString()}원` },
+                    { title: '소계', dataIndex: 'subtotalPrice', key: 'subtotalPrice', render: (v) => `${v.toLocaleString()}원` },
                   ]}
                   pagination={false}
-                  rowKey="productName"
+                  rowKey="productId"
                   size="small"
                 />
               </Descriptions.Item>
               <Descriptions.Item label="총 주문 금액" span={2}>
-                <Text
-                  strong
-                  style={{ fontSize: 16 }}
-                >{`${selectedOrder.totalPrice.toLocaleString()}원`}</Text>
+                <Text strong style={{ fontSize: 16 }}>{`${selectedOrder.totalPrice.toLocaleString()}원`}</Text>
               </Descriptions.Item>
             </Descriptions>
           )}


### PR DESCRIPTION
발주 및 반품 페이지 API 변경점 적용 및 로직 변경
- 반품페이지에서 승인처리된 발주 목록만 보이도록 변경
- 4 페이지 모두 페이지네이션, 필터링된 API 호출 적용
- 반품 관리에서 검색기능이 작동하지 않던 버그 수정

< 백엔드 수정사항 >
1. OrderRepository.java에서 Pageable의 정렬 기능 SQL 구문이 없음 =>  추가해서 사용

2. OrderService.java에서 productId가  Null 반환
itemResponses(77번 줄 코드)
itemResponses(105번 줄 코드)
itemResponses(142번 줄 코드) 
=> .productId(item.getProduct().getProductId()) 추가해서 사용

3. 발주 요청 페이지에서 발주 시 포인트 수정 기능 필요
4. 발주 조회 페이지에서 날짜 필터링 기능이 필요함