### PR TITLE
be/fix: 공지사항 키워드 필터링 시 타입 무시되는 문제 해결

### DIFF
--- a/backend/src/main/java/com/yeahyak/backend/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/yeahyak/backend/controller/AnnouncementController.java
@@ -1,22 +1,34 @@
 package com.yeahyak.backend.controller;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yeahyak.backend.dto.AnnouncementRequestDTO;
 import com.yeahyak.backend.dto.JinhoResponse;
 import com.yeahyak.backend.entity.Announcement;
 import com.yeahyak.backend.service.AnnouncementService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/announcements")
@@ -67,9 +79,11 @@ public class AnnouncementController {
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        Page<Announcement> pagedResult;
 
-        if (keyword != null && !keyword.isEmpty()) {
+        Page<Announcement> pagedResult;
+        if (keyword != null && !keyword.isEmpty() && type != null && !type.isEmpty()) {
+            pagedResult = announcementService.searchAnnouncementsWithType(type, keyword, pageable);
+        } else if (keyword != null && !keyword.isEmpty()) {
             pagedResult = announcementService.searchAnnouncements(keyword, pageable);
         } else {
             pagedResult = announcementService.findAllPaged(page, size, type);

--- a/backend/src/main/java/com/yeahyak/backend/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/com/yeahyak/backend/repository/AnnouncementRepository.java
@@ -1,16 +1,21 @@
 package com.yeahyak.backend.repository;
 
-import com.yeahyak.backend.entity.Announcement;
-import com.yeahyak.backend.entity.enums.AnnouncementType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.yeahyak.backend.entity.Announcement;
+import com.yeahyak.backend.entity.enums.AnnouncementType;
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
     Page<Announcement> findByType(AnnouncementType type, Pageable pageable);
 
     Page<Announcement> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-            String titleKeyword, String contentKeyword, Pageable pageable
+        String titleKeyword, String contentKeyword, Pageable pageable
+    );
+
+    Page<Announcement> findByTypeAndTitleContainingIgnoreCaseOrTypeAndContentContainingIgnoreCase(
+        AnnouncementType type1, String titleKeyword, AnnouncementType type2, String contentKeyword, Pageable pageable
     );
 }
 

--- a/backend/src/main/java/com/yeahyak/backend/service/AnnouncementService.java
+++ b/backend/src/main/java/com/yeahyak/backend/service/AnnouncementService.java
@@ -1,16 +1,5 @@
 package com.yeahyak.backend.service;
 
-import com.yeahyak.backend.entity.Announcement;
-import com.yeahyak.backend.entity.enums.AnnouncementType;
-import com.yeahyak.backend.repository.AnnouncementRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +8,19 @@ import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.yeahyak.backend.entity.Announcement;
+import com.yeahyak.backend.entity.enums.AnnouncementType;
+import com.yeahyak.backend.repository.AnnouncementRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -72,9 +74,17 @@ public class AnnouncementService {
         original.setUpdatedAt(LocalDateTime.now());
         return announcementRepository.save(original);
     }
+
     public Page<Announcement> searchAnnouncements(String keyword, Pageable pageable) {
         return announcementRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
                 keyword, keyword, pageable
+        );
+    }
+
+    public Page<Announcement> searchAnnouncementsWithType(String type, String keyword, Pageable pageable) {
+        AnnouncementType enumType = AnnouncementType.valueOf(type.toUpperCase());
+        return announcementRepository.findByTypeAndTitleContainingIgnoreCaseOrTypeAndContentContainingIgnoreCase(
+                enumType, keyword, enumType, keyword, pageable
         );
     }
 


### PR DESCRIPTION
예를 들어서 "type=NOTICE&keyword=안내"일 때 모든 type의 "안내" 검색 결과가 내려와서 type 필터링도 포함하게 수정했습니다.
검토 후 문제 없으면 머지해주세요 ദ്ദി(˵ •̀ ᴗ - ˵ ) ✧ 문제 있으면 클로즈 하고 직접 수정해주시면 감사하겠습니다!